### PR TITLE
Deprecate Plutus::Transaction.build

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    plutus (0.7.2)
+    plutus (0.8.0)
       rails (~> 3.1)
 
 GEM

--- a/README.markdown
+++ b/README.markdown
@@ -78,16 +78,16 @@ Let's assume we're accounting on an [Accrual basis](http://en.wikipedia.org/wiki
     >> Plutus::Asset.create(:name => "Cash")
     >> Plutus::Liability.create(:name => "Unearned Revenue")
 
-Next we'll build the transaction we want to record. Plutus provides a simple interface to build the transaction. 
+Next we'll build the transaction we want to record. Plutus uses ActiveRecord conventions build the transaction and its associated amounts. 
 
-    transaction = Plutus::Transaction.build(
+    transaction = Plutus::Transaction.new(
                     :description => "Order placed for widgets",
                     :debits => [
-                      {:account => "Cash", :amount => 100.00}], 
+                      {:account_name => "Cash", :amount => 100.00}], 
                     :credits => [
-                      {:account => "Unearned Revenue", :amount => 100.00}])
+                      {:account_name => "Unearned Revenue", :amount => 100.00}])
 
-The build method takes a hash consisting of a description, and an array of debits and credits. Each debit and credit item is a hash that specifies the amount, and the account to be debited or credited. Simply pass in the string name you used when you created the account. 
+Transactions must specify a description, as well as at least one credit and debit amount. `Amount`s must specify an amount value as well as an account, either by providing a `Plutus::Account` to `account` or by passing in an `account_name` string.
 
 Finally, save the transaction.
 
@@ -106,13 +106,13 @@ Often times a single transaction requires more than one type of account. A class
 
 And here's the transaction:
 
-    transaction = Plutus::Transaction.build(
+    transaction = Plutus::Transaction.new(
                     :description => "Sold some widgets",
                     :debits => [
-                      {:account => "Accounts Receivable", :amount => 50}], 
+                      {:account_name => "Accounts Receivable", :amount => 50}], 
                     :credits => [
-                      {:account => "Sales Revenue", :amount => 45},
-                      {:account => "Sales Tax Payable", :amount => 5}])
+                      {:account_name => "Sales Revenue", :amount => 45},
+                      {:account_name => "Sales Tax Payable", :amount => 5}])
     transaction.save
                        
 Associating Documents
@@ -126,14 +126,14 @@ Suppose we pull up our latest invoice in order to generate a transaction for plu
 
 Let's assume we're using the same transaction from the last example
 
-    transaction = Plutus::Transaction.build(
+    transaction = Plutus::Transaction.new(
                     :description => "Sold some widgets",
                     :commercial_document => invoice,
                     :debits => [
-                      {:account => "Accounts Receivable", :amount => invoice.total_amount}], 
+                      {:account_name => "Accounts Receivable", :amount => invoice.total_amount}], 
                     :credits => [
-                      {:account => "Sales Revenue", :amount => invoice.sales_amount},
-                      {:account => "Sales Tax Payable", :amount => invoice.tax_amount}])
+                      {:account_name => "Sales Revenue", :amount => invoice.sales_amount},
+                      {:account_name => "Sales Tax Payable", :amount => invoice.tax_amount}])
     transaction.save
 
 The commercial document attribute on the transaction is a polymorphic association allowing you to associate any record from your models with a transaction (i.e. Bills, Invoices, Receipts, Returns, etc.)
@@ -178,12 +178,12 @@ For example, let's assume the owner of a business wants to withdraw cash. First 
 
 We would then create the following transaction:
 
-    transaction = Plutus::Transaction.build(
+    transaction = Plutus::Transaction.new(
                     :description => "Owner withdrawing cash",
                     :debits => [
-                      {:account => "Drawing", :amount => 1000}], 
+                      {:account_name => "Drawing", :amount => 1000}], 
                     :credits => [
-                      {:account => "Cash", :amount => 1000}])
+                      {:account_name => "Cash", :amount => 1000}])
     transaction.save
 
 To make the example clearer, imagine instead that the owner decides to invest his money into the business in exchange for some type of equity security. In this case we might have the following accounts:
@@ -193,12 +193,12 @@ To make the example clearer, imagine instead that the owner decides to invest hi
 
 And out transaction would be:
 
-    transaction = Plutus::Transaction.build(
+    transaction = Plutus::Transaction.new(
                     :description => "Owner investing cash",
                     :debits => [
-                      {:account => "Cash", :amount => 1000}], 
+                      {:account_name => "Cash", :amount => 1000}], 
                     :credits => [
-                      {:account => "Common Stock", :amount => 1000}])
+                      {:account_name => "Common Stock", :amount => 1000}])
     transaction.save
 
 In this case, we've increase our cash Asset, and simultaneously increased the other side of our accounting equation in

--- a/app/models/plutus/amount.rb
+++ b/app/models/plutus/amount.rb
@@ -6,11 +6,29 @@ module Plutus
   #
   # @author Michael Bulat
   class Amount < ActiveRecord::Base
-    attr_accessible :account, :amount, :transaction
+    attr_accessible :account, :account_name, :amount, :transaction
     
     belongs_to :transaction
     belongs_to :account
 
     validates_presence_of :type, :amount, :transaction, :account
+    
+    # Assign an account by name
+    def account_name=(name)
+      self.account = Account.find_by_name!(name)
+    end
+    
+    protected
+    
+    # Support constructing amounts with account = "name" syntax
+    def account_with_name_lookup=(v)
+      if v.kind_of?(String)
+        ActiveSupport::Deprecation.warn("Plutus was given an :account String (use account_name instead)", caller)
+        self.account_name = v
+      else
+        self.account_without_name_lookup = v
+      end
+    end
+    alias_method_chain :account=, :name_lookup
   end
 end

--- a/lib/plutus/version.rb
+++ b/lib/plutus/version.rb
@@ -1,3 +1,3 @@
 module Plutus
-  VERSION = "0.7.2"
+  VERSION = "0.8.0"
 end

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -67,25 +67,135 @@ module Plutus
       saved_transaction = Transaction.find(transaction.id)
       saved_transaction.commercial_document.should == mock_document
     end
+    
+    context "given a set of accounts" do
+      let(:mock_document) { FactoryGirl.create(:asset) }
+      let!(:accounts_receivable) { FactoryGirl.create(:asset, name: "Accounts Receivable") }
+      let!(:sales_revenue) { FactoryGirl.create(:revenue, name: "Sales Revenue") }
+      let!(:sales_tax_payable) { FactoryGirl.create(:liability, name: "Sales Tax Payable") }
+      
+      shared_examples_for 'a built-from-hash Plutus::Transaction' do
+        its(:credit_amounts) { should_not be_empty }
+        its(:debit_amounts) { should_not be_empty }
+        it { should be_valid }
+        
+        context "when saved" do
+          before { transaction.save! }
+          its(:id) { should_not be_nil }
+          
+          context "when reloaded" do
+            let(:saved_transaction) { Transaction.find(transaction.id) }
+            subject { saved_transaction }
+            it("should have the correct commercial document") {
+              saved_transaction.commercial_document == mock_document
+            }
+          end
+        end
+      end
+      
+      describe ".new" do
+        let(:transaction) { Transaction.new(hash) }
+        subject { transaction }
 
-    it "should allow building a transaction and credit and debits with a hash" do
-      FactoryGirl.create(:asset, name: "Accounts Receivable")
-      FactoryGirl.create(:revenue, name: "Sales Revenue")
-      FactoryGirl.create(:liability, name: "Sales Tax Payable")
-      mock_document = FactoryGirl.create(:asset)
-      transaction = Transaction.build(
-        description: "Sold some widgets",
-        commercial_document: mock_document,
-        debits: [
-          {account: "Accounts Receivable", amount: 50}], 
-        credits: [
-          {account: "Sales Revenue", amount: 45},
-          {account: "Sales Tax Payable", amount: 5}])
-      transaction.save!
+        context "when given a credit/debits hash with :account => Account" do
+          let(:hash) {
+            {
+              description: "Sold some widgets",
+              commercial_document: mock_document,
+              debits: [{account: accounts_receivable, amount: 50}], 
+              credits: [
+                {account: sales_revenue, amount: 45},
+                {account: sales_tax_payable, amount: 5}
+                ]
+            }
+          }
+          include_examples 'a built-from-hash Plutus::Transaction'
+        end
 
-      saved_transaction = Transaction.find(transaction.id)
-      saved_transaction.commercial_document.should == mock_document
+        context "when given a credit/debits hash with :account_name => String" do
+          let(:hash) {
+            {
+              description: "Sold some widgets",
+              commercial_document: mock_document,
+              debits: [{account_name: accounts_receivable.name, amount: 50}], 
+              credits: [
+                {account_name: sales_revenue.name, amount: 45},
+                {account_name: sales_tax_payable.name, amount: 5}
+                ]
+            }
+          }
+          include_examples 'a built-from-hash Plutus::Transaction'
+        end
+
+        context "when given a credit/debits hash with :account => String" do
+          let(:hash) {
+            {
+              description: "Sold some widgets",
+              commercial_document: mock_document,
+              debits: [{account: accounts_receivable.name, amount: 50}], 
+              credits: [
+                {account: sales_revenue.name, amount: 45},
+                {account: sales_tax_payable.name, amount: 5}
+                ]
+            }
+          }
+          
+          before { ::ActiveSupport::Deprecation.silenced = true }
+          after { ::ActiveSupport::Deprecation.silenced = false }
+          
+          it("should be deprecated") {
+            # one deprecation per account looked up
+            ::ActiveSupport::Deprecation.should_receive(:warn).exactly(3).times
+            transaction
+          }
+          
+          include_examples 'a built-from-hash Plutus::Transaction'
+        end
+      end
+
+      describe ".build" do
+        let(:transaction) { Transaction.build(hash) }
+        subject { transaction }
+        
+        before { ::ActiveSupport::Deprecation.silenced = true }
+        after { ::ActiveSupport::Deprecation.silenced = false }
+
+        context "when used at all" do
+          let(:hash) { Hash.new }
+          
+          it("should be deprecated") {
+            # .build is the only thing deprecated
+            ::ActiveSupport::Deprecation.should_receive(:warn).once
+            transaction
+          }
+        end
+
+        context "when given a credit/debits hash with :account => String" do
+          let(:hash) {
+            {
+              description: "Sold some widgets",
+              commercial_document: mock_document,
+              debits: [{account: accounts_receivable.name, amount: 50}], 
+              credits: [
+                {account: sales_revenue.name, amount: 45},
+                {account: sales_tax_payable.name, amount: 5}
+                ]
+            }
+          }
+          
+          it("should be deprecated") {
+            # one deprecation for build, plus three for accounts as strings
+            ::ActiveSupport::Deprecation.should_receive(:warn).exactly(4).times
+            transaction
+          }
+          
+          include_examples 'a built-from-hash Plutus::Transaction'
+        end
+        
+      end
+
     end
+
 
   end
 end


### PR DESCRIPTION
ActiveRecord already has conventions for constructing objects from hashes. Plutus can and should use them, rather than reinventing this functionality with a custom `.build` method.

Starting with:

    Transaction.build(credits: [{account: "Foo", amount: 50}])

Using [`accepts_nested_attributes_for`](http://api.rubyonrails.org/classes/ActiveRecord/NestedAttributes/ClassMethods.html#method-i-accepts_nested_attributes_for) and `attr_accessible`, this becomes:

    foo = Account.find_by_name("Foo")
    Transaction.new(credit_amounts_attributes: [{account: foo, amount: 50}])

As a next step, we can alias `:credits=` to `:credit_amounts_attributes=`:

    foo = Account.find_by_name("Foo")
    Transaction.new(credits: [{account: foo, amount: 50}])

Then, we can define a `Plutus::Amount#account_name=` method, which performs this lookup and sets `#account=`:

    Transaction.new(credits: [{account_name: "Foo", amount: 50}])

This is the preferred syntax. `account_name=` accepts a `String` (while `account=` accepts an `Account`), and `Transaction.new` is used to instantiate a new `Transaction`.

We can then add a version of `#account=` that supports Strings, delegating to `#account_name=` after emitting a deprecation warning, and a similar `Transaction.build` function. This lets us ultimately support the original syntax again with only minimal compatibility code:

    Transaction.build(credits: [{account: "Foo", amount: 50}])
    DEPRECATION WARNING: Plutus::Transaction.build() is deprecated (use new instead)
    DEPRECATION WARNING: Plutus was given an :account String (use account_name instead)

This changeset thus supports the previous `build` method, but with deprecation warnings, since `.build` is no longer needed and ActiveRecord (sensibly) expects `account=` to be given an `Account`. Still, this is an interface change. Since the existing syntax still works, I chose a minor version bump, with the intention of removing support for the deprecated syntax at a later date.