### PR TITLE
Add transaction_date to entries

### DIFF
--- a/app/models/plutus/entry.rb
+++ b/app/models/plutus/entry.rb
@@ -40,14 +40,14 @@ module Plutus
     #   entry = Plutus::Entry.build(
     #     description: "Sold some widgets",
     #     debits: [
-    #       {account: "Accounts Receivable", amount: 50}], 
+    #       {account: "Accounts Receivable", amount: 50}],
     #     credits: [
     #       {account: "Sales Revenue", amount: 45},
     #       {account: "Sales Tax Payable", amount: 5}])
     #
     # @return [Plutus::Entry] A Entry with built credit and debit objects ready for saving
     def self.build(hash)
-      entry = Entry.new(:description => hash[:description], :commercial_document => hash[:commercial_document])
+      entry = Entry.new(:description => hash[:description], :commercial_document => hash[:commercial_document], :transaction_date => hash[:transaction_date])
       hash[:debits].each do |debit|
         a = Account.find_by_name(debit[:account])
         entry.debit_amounts << DebitAmount.new(:account => a, :amount => debit[:amount], :entry => entry)

--- a/lib/generators/plutus/templates/migration.rb
+++ b/lib/generators/plutus/templates/migration.rb
@@ -13,6 +13,7 @@ class CreatePlutusTables < ActiveRecord::Migration
       t.string :description
       t.integer :commercial_document_id
       t.string :commercial_document_type
+      t.date :transaction_date
 
       t.timestamps
     end
@@ -23,7 +24,7 @@ class CreatePlutusTables < ActiveRecord::Migration
       t.references :account
       t.references :entry
       t.decimal :amount, :precision => 20, :scale => 10
-    end 
+    end
     add_index :plutus_amounts, :type
     add_index :plutus_amounts, [:account_id, :entry_id]
     add_index :plutus_amounts, [:entry_id, :account_id]


### PR DESCRIPTION
I'm a full-time accountant turned developer. While created_at works for some entries, there are many times where an entry is made days after a transaction, and a "custom" transaction_date.

A few examples: 
- Bookkeepers getting a list of transactions from their clients
- Accrual entries after a month or year end (i.e. accountants make entries on July 1 to "close the books" for June. The entry is made on July 1, but it affects June's numbers.)
- Any type of entry that is made manually

My solution in the code gives the functionality I think is needed, but if you had a better idea I'm open to learn.
