### PR TITLE
Refactoring to dry up account subclasses, as discussed in PR #41

### DIFF
--- a/app/models/plutus/asset.rb
+++ b/app/models/plutus/asset.rb
@@ -9,6 +9,8 @@ module Plutus
   # @author Michael Bulat
   class Asset < Account
 
+    self.normal_credit_balance = false
+
     # The balance of the account.
     #
     # Assets have normal debit balances, so the credits are subtracted from the debits
@@ -20,11 +22,7 @@ module Plutus
     #
     # @return [BigDecimal] The decimal value balance
     def balance
-      unless contra
-        debits_balance - credits_balance
-      else
-        credits_balance - debits_balance
-      end
+      super
     end
 
     # This class method is used to return
@@ -38,16 +36,7 @@ module Plutus
     #
     # @return [BigDecimal] The decimal value balance
     def self.balance
-      accounts_balance = BigDecimal.new('0')
-      accounts = self.all
-      accounts.each do |asset|
-        unless asset.contra
-          accounts_balance += asset.balance
-        else
-          accounts_balance -= asset.balance
-        end
-      end
-      accounts_balance
+      super
     end
   end
 end

--- a/app/models/plutus/equity.rb
+++ b/app/models/plutus/equity.rb
@@ -9,6 +9,8 @@ module Plutus
   # @author Michael Bulat
   class Equity < Account
 
+    self.normal_credit_balance = true
+
     # The balance of the account.
     #
     # Equity accounts have normal credit balances, so the debits are subtracted from the credits
@@ -20,11 +22,7 @@ module Plutus
     #
     # @return [BigDecimal] The decimal value balance
     def balance
-      unless contra
-        credits_balance - debits_balance
-      else
-        debits_balance - credits_balance
-      end
+      super
     end
 
     # This class method is used to return
@@ -38,16 +36,7 @@ module Plutus
     #
     # @return [BigDecimal] The decimal value balance
     def self.balance
-      accounts_balance = BigDecimal.new('0')
-      accounts = self.all
-      accounts.each do |equity|
-        unless equity.contra
-          accounts_balance += equity.balance
-        else
-          accounts_balance -= equity.balance
-        end
-      end
-      accounts_balance
+      super
     end
   end
 end

--- a/app/models/plutus/expense.rb
+++ b/app/models/plutus/expense.rb
@@ -9,6 +9,8 @@ module Plutus
   # @author Michael Bulat
   class Expense < Account
 
+    self.normal_credit_balance = false
+
     # The balance of the account.
     #
     # Expenses have normal debit balances, so the credits are subtracted from the debits
@@ -20,11 +22,7 @@ module Plutus
     #
     # @return [BigDecimal] The decimal value balance
     def balance
-      unless contra
-        debits_balance - credits_balance
-      else
-        credits_balance - debits_balance
-      end
+      super
     end
 
     # This class method is used to return
@@ -38,16 +36,7 @@ module Plutus
     #
     # @return [BigDecimal] The decimal value balance
     def self.balance
-      accounts_balance = BigDecimal.new('0')
-      accounts = self.all
-      accounts.each do |expense|
-        unless expense.contra
-          accounts_balance += expense.balance
-        else
-          accounts_balance -= expense.balance
-        end
-      end
-      accounts_balance
+      super
     end
   end
 end

--- a/app/models/plutus/liability.rb
+++ b/app/models/plutus/liability.rb
@@ -9,6 +9,8 @@ module Plutus
   # @author Michael Bulat
   class Liability < Account
 
+    self.normal_credit_balance = true
+
     # The balance of the account.
     #
     # Liability accounts have normal credit balances, so the debits are subtracted from the credits
@@ -20,11 +22,7 @@ module Plutus
     #
     # @return [BigDecimal] The decimal value balance
     def balance
-      unless contra
-        credits_balance - debits_balance
-      else
-        debits_balance - credits_balance
-      end
+      super
     end
 
     # This class method is used to return
@@ -38,16 +36,7 @@ module Plutus
     #
     # @return [BigDecimal] The decimal value balance
     def self.balance
-      accounts_balance = BigDecimal.new('0')
-      accounts = self.all
-      accounts.each do |liability|
-        unless liability.contra
-          accounts_balance += liability.balance
-        else
-          accounts_balance -= liability.balance
-        end
-      end
-      accounts_balance
+      super
     end
   end
 end

--- a/app/models/plutus/revenue.rb
+++ b/app/models/plutus/revenue.rb
@@ -9,6 +9,8 @@ module Plutus
   # @author Michael Bulat
   class Revenue < Account
 
+    self.normal_credit_balance = true
+
     # The balance of the account.
     #
     # Revenue accounts have normal credit balances, so the debits are subtracted from the credits
@@ -20,11 +22,7 @@ module Plutus
     #
     # @return [BigDecimal] The decimal value balance
     def balance
-      unless contra
-        credits_balance - debits_balance
-      else
-        debits_balance - credits_balance
-      end
+      super
     end
 
     # This class method is used to return
@@ -38,16 +36,7 @@ module Plutus
     #
     # @return [BigDecimal] The decimal value balance
     def self.balance
-      accounts_balance = BigDecimal.new('0')
-      accounts = self.all
-      accounts.each do |revenue|
-        unless revenue.contra
-          accounts_balance += revenue.balance
-        else
-          accounts_balance -= revenue.balance
-        end
-      end
-      accounts_balance
+      super
     end
   end
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -18,7 +18,13 @@ module Plutus
       end
     end
 
-    it { should_not respond_to(:balance) }
+    it "calling the instance method #balance should raise a NoMethodError" do
+      expect { subject.balance }.to raise_error NoMethodError, "undefined method 'balance'"
+    end
+
+    it "calling the class method ::balance should raise a NoMethodError" do
+      expect { subject.class.balance }.to raise_error NoMethodError, "undefined method 'balance'"
+    end
 
     describe ".trial_balance" do
       subject { Account.trial_balance }


### PR DESCRIPTION
As discussed in #41 comments.

> I was looking at those models because they look very similar (they being: liabilities, expenses, equities, assets).
>
> Especially, the class method, #balance... Would you consider refactoring this code to avoid the duplication, or is it purposefully duplicated for clarity?
>
> The instance method #balance is also quite similar. It seems you could refactor the occurrences of that instance method as well. Maybe use a class attribute on Account's subclasses to drive an instance method defined on Account. 

 - Refactors ::balance and #balance methods defined in each of Account's subclasses
    to the Account model.
  - Retain original documentation
  - Adds documentation for the methods in their new locations (with a note on intended use)
  - Prevents calling ::balance or #balance on the Account class/instance directly
  - Adds specs for preventing calling ::balance and #balance on the Account class/instance directly