### PR TITLE
merge contributing guidelines into master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Plutus welcomes contributions from *everyone*.
+
+First of all, thank you for considering to help make Plutus better. Here are some ways you can contribute:
+
+  - by [reporting bugs you encounter](https://github.com/mbulat/plutus/issues/new)
+  - by closing issues that are not complete
+  - by adding a failing test for reproducible [reported bugs](https://github.com/mbulat/plutus/issues)
+  - by reviewing [pull requests](https://github.com/mbulat/plutus/pulls) and suggesting improvements
+  - by writing code (no patch is too small! fix typos or bad whitespace)
+
+Thanks for helping us make Plutus better.
+
+# Adding new features
+
+If you would like to add a new feature to Plutus, please follow these steps:
+
+  1. First, check [github issues](https://github.com/mbulat/plutus/issues) to see if the feature has been discussed
+  2. For complex features or questions, [Discuss the issue](https://groups.google.com/d/forum/plutus-gem) at the plutus mailing list.
+  3. Open an [enhancement issues](https://github.com/mbulat/plutus/labels/enhancement) and make sure to add the enhancement label
+  4. Base your commits on the 'develop' branch, since we follow [Git Flow](http://nvie.com/posts/a-successful-git-branching-model/), and don't add new features to old releases.
+  5. Commit the code and at least one test covering your changes to a feature branch in your fork.
+  5. Don't commit any changes to gemspec or change the version number
+  6. Send us a [pull request](https://help.github.com/articles/using-pull-requests) from your feature branch.
+
+If you don't hear back immediately, don’t get discouraged! We all have day jobs, but we respond to most tickets within a day or two.
+
+If the pull request is merged, testing will commence on our staging systems to ensure that the new feature doesn't cause any problems for anyone in production. We'll then merge the code into the master branch and push a new gem version!
+
+# Discussing Plutus
+
+If you'd like to discuss features, ask questions, or just engage in general Plutus-focused discussion, please see the [Plutus mailing list](https://groups.google.com/d/forum/plutus-gem) on Google Groups.

--- a/README.markdown
+++ b/README.markdown
@@ -325,8 +325,10 @@ Testing
 
 [Rspec](http://rspec.info/) tests are provided. Run `bundle install` then `rake`.
 
-Contributors
-============
+Contributing and Contributors
+=============================
+
+There's a guide to contributing to Plutus (both code and general help) over in [CONTRIBUTING](https://github.com/mbulat/plutus/blob/master/CONTRIBUTING.md)
 
 Many thanks to all our contributors! Check them all at:
 


### PR DESCRIPTION
Currently the guidelines for contributing only appear once a github user selects develop as the base branch for a PR.  Once the guidelines are merged into master, the prompt "Please Review the [guidelines for contributing](https://github.com/mbulat/plutus/blob/develop/CONTRIBUTING.md) to this repository" should be more apparent to potential contributors.