### PR TITLE
Avoid using unless-else constructs

### DIFF
--- a/app/models/plutus/account.rb
+++ b/app/models/plutus/account.rb
@@ -60,14 +60,14 @@ module Plutus
     #
     # @return [BigDecimal] The decimal value balance
     def balance
-      unless self.class == Plutus::Account
+      if self.class == Plutus::Account
+        raise(NoMethodError, "undefined method 'balance'")
+      else
         if self.normal_credit_balance ^ contra
           credits_balance - debits_balance
         else
           debits_balance - credits_balance
         end
-      else
-        raise(NoMethodError, "undefined method 'balance'")
       end
     end
 
@@ -104,7 +104,9 @@ module Plutus
     #
     # @return [BigDecimal] The decimal value balance
     def self.balance
-      unless self.new.class == Plutus::Account
+      if self.new.class == Plutus::Account
+        raise(NoMethodError, "undefined method 'balance'")
+      else
         accounts_balance = BigDecimal.new('0')
         accounts = self.all
         accounts.each do |account|
@@ -115,8 +117,6 @@ module Plutus
           end
         end
         accounts_balance
-      else
-        raise(NoMethodError, "undefined method 'balance'")
       end
     end
 
@@ -129,10 +129,10 @@ module Plutus
     #
     # @return [BigDecimal] The decimal value balance of all accounts
     def self.trial_balance
-      unless self.new.class == Plutus::Account
-        raise(NoMethodError, "undefined method 'trial_balance'")
-      else
+      if self.new.class == Plutus::Account
         Plutus::Asset.balance - (Plutus::Liability.balance + Plutus::Equity.balance + Plutus::Revenue.balance - Plutus::Expense.balance)
+      else
+        raise(NoMethodError, "undefined method 'trial_balance'")
       end
     end
 

--- a/app/models/plutus/account.rb
+++ b/app/models/plutus/account.rb
@@ -110,10 +110,10 @@ module Plutus
         accounts_balance = BigDecimal.new('0')
         accounts = self.all
         accounts.each do |account|
-          unless account.contra
-            accounts_balance += account.balance
-          else
+          if account.contra
             accounts_balance -= account.balance
+          else
+            accounts_balance += account.balance
           end
         end
         accounts_balance


### PR DESCRIPTION
Checking conditions with `unless` should not be combined with an `else` part. It's difficult to read and to follow the logic of the conditional statement. This pull-request changes those to `if-else` statements and changes the blocks on each part of the conditionals in order to keep the same logic intact.