### PR TITLE
Add account amounts and entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Not Released
+
+- Add `Account#amounts` and `Account#entries` to get all amounts and entries, respectively

--- a/app/models/plutus/account.rb
+++ b/app/models/plutus/account.rb
@@ -32,8 +32,10 @@ module Plutus
   class Account < ActiveRecord::Base
     class_attribute :normal_credit_balance
 
+    has_many :amounts
     has_many :credit_amounts, :extend => AmountsExtension, :class_name => 'Plutus::CreditAmount'
     has_many :debit_amounts, :extend => AmountsExtension, :class_name => 'Plutus::DebitAmount'
+    has_many :entries, through: :amounts, source: :entry
     has_many :credit_entries, :through => :credit_amounts, :source => :entry, :class_name => 'Plutus::Entry'
     has_many :debit_entries, :through => :debit_amounts, :source => :entry, :class_name => 'Plutus::Entry'
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -72,5 +72,62 @@ module Plutus
         it { should == 0 }
       end
     end
+
+    describe "#amounts" do
+      it "returns all credit and debit amounts" do
+        equity = FactoryGirl.create(:equity)
+        asset = FactoryGirl.create(:asset)
+        expense = FactoryGirl.create(:expense)
+
+        investment = Entry.new(
+          description: "Initial investment",
+          date: Date.today,
+          debits: [{ account_name: equity.name, amount: 1000 }],
+          credits: [{ account_name: asset.name, amount: 1000 }],
+        )
+        investment.save
+
+        purchase = Entry.new(
+          description: "First computer",
+          date: Date.today,
+          debits: [{ account_name: asset.name, amount: 900 }],
+          credits: [{ account_name: expense.name, amount: 900 }],
+        )
+        purchase.save
+
+        expect(equity.amounts.size).to eq 1
+        expect(asset.amounts.size).to eq 2
+        expect(expense.amounts.size).to eq 1
+      end
+    end
+
+    describe "#entries" do
+      it "returns all credit and debit entries" do
+        equity = FactoryGirl.create(:equity)
+        asset = FactoryGirl.create(:asset)
+        expense = FactoryGirl.create(:expense)
+
+        investment = Entry.new(
+          description: "Initial investment",
+          date: Date.today,
+          debits: [{ account_name: equity.name, amount: 1000 }],
+          credits: [{ account_name: asset.name, amount: 1000 }],
+        )
+        investment.save
+
+        purchase = Entry.new(
+          description: "First computer",
+          date: Date.today,
+          debits: [{ account_name: asset.name, amount: 900 }],
+          credits: [{ account_name: expense.name, amount: 900 }],
+        )
+        purchase.save
+
+        expect(equity.entries.size).to eq 1
+        expect(asset.entries.size).to eq 2
+        expect(expense.entries.size).to eq 1
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This makes it easier to display a table of debits and credits of an account. It will be typically used like this:

```haml
%table
  #-...
  - @account.entries.each do |entry|
    %tr
      ...
```