### PR TITLE
Allow destruction of debit/credit amounts from entry objects

### DIFF
--- a/app/models/plutus/amounts_extension.rb
+++ b/app/models/plutus/amounts_extension.rb
@@ -32,10 +32,8 @@ module Plutus
     def balance_for_new_record
       balance = BigDecimal.new('0')
       each do |amount_record|
-        if amount_record.amount
-          balance += amount_record.amount
-        else
-          balance = nil
+        if amount_record.amount && !amount_record.marked_for_destruction?
+          balance += amount_record.amount # unless amount_record.marked_for_destruction?
         end
       end
       return balance

--- a/app/models/plutus/entry.rb
+++ b/app/models/plutus/entry.rb
@@ -35,7 +35,7 @@ module Plutus
     validate :amounts_cancel?
 
     # Support construction using 'credits' and 'debits' keys
-    accepts_nested_attributes_for :credit_amounts, :debit_amounts
+    accepts_nested_attributes_for :credit_amounts, :debit_amounts, allow_destroy: true
     alias_method :credits=, :credit_amounts_attributes=
     alias_method :debits=, :debit_amounts_attributes=
     # attr_accessible :credits, :debits

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -69,6 +69,15 @@ module Plutus
       entry.errors['base'].should == ["The credit and debit amounts are not equal"]
     end
 
+    it "should ignore debit and credit amounts marked for destruction to cancel" do
+      entry.credit_amounts << FactoryGirl.build(:credit_amount, :amount => 100, :entry => entry)
+      debit_amount = FactoryGirl.build(:debit_amount, :amount => 100, :entry => entry)
+      debit_amount.mark_for_destruction
+      entry.debit_amounts << debit_amount
+      entry.should_not be_valid
+      entry.errors['base'].should == ["The credit and debit amounts are not equal"]
+    end
+
     it "should have a polymorphic commercial document associations" do
       mock_document = FactoryGirl.create(:asset) # one would never do this, but it allows us to not require a migration for the test
       entry = FactoryGirl.build(:entry_with_credit_and_debit, commercial_document: mock_document)


### PR DESCRIPTION
I'm currently building an entry form and noticed that updating a `Plutus::Entry` and "removing" `amounts` through the form (`entry: { debit_amounts_attributes: { id: 100, :_destroy => 1 } }`) causes the entry to fail validation because `balance_for_new_record` does not consider `amounts` which are marked for destruction.

This PR fixes this.