### PR TITLE
Fixes TypeError that may be raised if there's a top-level `Account` module

### DIFF
--- a/app/controllers/plutus/accounts_controller.rb
+++ b/app/controllers/plutus/accounts_controller.rb
@@ -10,7 +10,7 @@ module Plutus
   # controller will inherit.
   #
   # @author Michael Bulat
-  class AccountsController < Plutus::ApplicationController
+  class AccountsController < ::Plutus::ApplicationController
     unloadable
 
     # @example

--- a/app/controllers/plutus/reports_controller.rb
+++ b/app/controllers/plutus/reports_controller.rb
@@ -5,7 +5,7 @@ module Plutus
   # controller will inherit.
   #
   # @author Michael Bulat
-  class ReportsController <  Plutus::ApplicationController
+  class ReportsController < ::Plutus::ApplicationController
     unloadable
 
     # @example

--- a/app/models/plutus/asset.rb
+++ b/app/models/plutus/asset.rb
@@ -7,7 +7,7 @@ module Plutus
   # @see http://en.wikipedia.org/wiki/Asset Assets
   #
   # @author Michael Bulat
-  class Asset < Account
+  class Asset < ::Plutus::Account
 
     self.normal_credit_balance = false
 

--- a/app/models/plutus/credit_amount.rb
+++ b/app/models/plutus/credit_amount.rb
@@ -5,6 +5,6 @@ module Plutus
   #     credit_amount = Plutus::CreditAmount.new(:account => revenue, :amount => 1000)
   #
   # @author Michael Bulat
-  class CreditAmount < Amount
+  class CreditAmount < ::Plutus::Amount
   end
 end

--- a/app/models/plutus/debit_amount.rb
+++ b/app/models/plutus/debit_amount.rb
@@ -5,6 +5,6 @@ module Plutus
   #     debit_amount = Plutus::DebitAmount.new(:account => cash, :amount => 1000)
   #
   # @author Michael Bulat
-  class DebitAmount < Amount
+  class DebitAmount < ::Plutus::Amount
   end
 end

--- a/app/models/plutus/equity.rb
+++ b/app/models/plutus/equity.rb
@@ -7,7 +7,7 @@ module Plutus
   # @see http://en.wikipedia.org/wiki/Equity_(finance) Equity
   #
   # @author Michael Bulat
-  class Equity < Account
+  class Equity < ::Plutus::Account
 
     self.normal_credit_balance = true
 

--- a/app/models/plutus/expense.rb
+++ b/app/models/plutus/expense.rb
@@ -7,7 +7,7 @@ module Plutus
   # @see http://en.wikipedia.org/wiki/Expense Expenses
   #
   # @author Michael Bulat
-  class Expense < Account
+  class Expense < ::Plutus::Account
 
     self.normal_credit_balance = false
 

--- a/app/models/plutus/liability.rb
+++ b/app/models/plutus/liability.rb
@@ -7,7 +7,7 @@ module Plutus
   # @see http://en.wikipedia.org/wiki/Liability_(financial_accounting) Liability
   #
   # @author Michael Bulat
-  class Liability < Account
+  class Liability < ::Plutus::Account
 
     self.normal_credit_balance = true
 

--- a/app/models/plutus/revenue.rb
+++ b/app/models/plutus/revenue.rb
@@ -7,7 +7,7 @@ module Plutus
   # @see http://en.wikipedia.org/wiki/Revenue Revenue
   #
   # @author Michael Bulat
-  class Revenue < Account
+  class Revenue < ::Plutus::Account
 
     self.normal_credit_balance = true
 


### PR DESCRIPTION
```
TypeError: superclass must be a Class (Module given)
```
