### PR TITLE
Remove coffeescript

### DIFF
--- a/app/assets/javascripts/plutus/reports.js
+++ b/app/assets/javascripts/plutus/reports.js
@@ -1,0 +1,5 @@
+jQuery(function() {
+  return $('.datepicker').datepicker({
+    dateFormat: "yy-mm-dd"
+  });
+});

--- a/app/assets/javascripts/plutus/reports.js.coffee
+++ b/app/assets/javascripts/plutus/reports.js.coffee
@@ -1,2 +1,0 @@
-jQuery ->
-  $('.datepicker').datepicker dateFormat: "yy-mm-dd"


### PR DESCRIPTION
Many modern rails projects skip the coffeescript dependency. It seemed simple enough to rip it out of here, so I did.