### PR TITLE
Add commercial_entity to accounts

### DIFF
--- a/app/models/plutus/account.rb
+++ b/app/models/plutus/account.rb
@@ -47,6 +47,12 @@ module Plutus
       include Plutus::NoTenancy
     end
 
+    if ActiveRecord::VERSION::MAJOR > 4
+      belongs_to :commercial_entity, :polymorphic => true, optional: true
+    else
+      belongs_to :commercial_entity, :polymorphic => true
+    end
+
     # The balance of the account. This instance method is intended for use only
     # on instances of account subclasses.
     #

--- a/fixture_rails_root/Gemfile
+++ b/fixture_rails_root/Gemfile
@@ -52,4 +52,4 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem "plutus", path: "~/repos/plutus"
+gem "plutus", path: "../"

--- a/fixture_rails_root/Gemfile.lock
+++ b/fixture_rails_root/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    plutus (0.12.2)
+    plutus (0.13)
       jquery-rails (>= 3.0)
       jquery-ui-rails (>= 4.2.2)
       kaminari (~> 1.0)
@@ -74,18 +74,18 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
-    kaminari (1.0.1)
+    kaminari (1.1.1)
       activesupport (>= 4.1.0)
-      kaminari-actionview (= 1.0.1)
-      kaminari-activerecord (= 1.0.1)
-      kaminari-core (= 1.0.1)
-    kaminari-actionview (1.0.1)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
       actionview
-      kaminari-core (= 1.0.1)
-    kaminari-activerecord (1.0.1)
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
       activerecord
-      kaminari-core (= 1.0.1)
-    kaminari-core (1.0.1)
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -195,4 +195,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.15.1
+   1.16.6

--- a/fixture_rails_root/db/migrate/20190110100325_add_commercial_entity_to_plutus_accounts.rb
+++ b/fixture_rails_root/db/migrate/20190110100325_add_commercial_entity_to_plutus_accounts.rb
@@ -1,0 +1,7 @@
+class AddCommercialEntityToPlutusAccounts < ActiveRecord::Migration[4.2]
+  def change
+    add_column :plutus_accounts, :commercial_entity_id, :integer
+    add_column :plutus_accounts, :commercial_entity_type, :string
+    add_index :plutus_accounts, [:commercial_entity_type, :commercial_entity_id], :name => "index_accounts_on_commercial_entity"
+  end
+end

--- a/fixture_rails_root/db/schema.rb
+++ b/fixture_rails_root/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170710174915) do
+ActiveRecord::Schema.define(version: 20190110100325) do
 
   create_table "plutus_accounts", force: :cascade do |t|
     t.string "name"
@@ -19,6 +19,9 @@ ActiveRecord::Schema.define(version: 20170710174915) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "tenant_id"
+    t.integer "commercial_entity_id"
+    t.string "commercial_entity_type"
+    t.index ["commercial_entity_type", "commercial_entity_id"], name: "index_accounts_on_commercial_entity"
     t.index ["name", "type"], name: "index_plutus_accounts_on_name_and_type"
   end
 

--- a/lib/generators/plutus/add_commercial_entity_upgrade_generator.rb
+++ b/lib/generators/plutus/add_commercial_entity_upgrade_generator.rb
@@ -1,0 +1,11 @@
+require 'rails/generators'
+require 'rails/generators/migration'
+require_relative 'base_generator'
+
+module Plutus
+  class AddCommercialEntityUpgradeGenerator < BaseGenerator
+    def create_migration_file
+      migration_template 'add_commercial_entity_migration.rb', 'db/migrate/add_commercial_entity_to_plutus_accounts.rb'
+    end
+  end
+end

--- a/lib/generators/plutus/templates/add_commercial_entity_migration.rb
+++ b/lib/generators/plutus/templates/add_commercial_entity_migration.rb
@@ -1,0 +1,7 @@
+class AddCommercialEntityToPlutusAccounts < ActiveRecord::Migration[4.2]
+  def change
+    add_column :plutus_accounts, :commercial_entity_id, :integer
+    add_column :plutus_accounts, :commercial_entity_type, :string
+    add_index :plutus_accounts, [:commercial_entity_type, :commercial_entity_id], :name => "index_accounts_on_commercial_entity"
+  end
+end

--- a/lib/generators/plutus/templates/migration.rb
+++ b/lib/generators/plutus/templates/migration.rb
@@ -4,10 +4,13 @@ class CreatePlutusTables < ActiveRecord::Migration[4.2]
       t.string :name
       t.string :type
       t.boolean :contra, default: false
+      t.integer :commercial_entity_id
+      t.string :commercial_entity_type
 
       t.timestamps
     end
     add_index :plutus_accounts, [:name, :type]
+    add_index :plutus_accounts, [:commercial_entity_type, :commercial_entity_id], :name => "index_accounts_on_commercial_entity"
 
     create_table :plutus_entries do |t|
       t.string :description

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -129,5 +129,13 @@ module Plutus
       end
     end
 
+    it "should have a polymorphic commercial entity associations" do
+      mock_entity = FactoryGirl.create(:asset) # one would never do this, but it allows us to not require a migration for the test
+      entry = FactoryGirl.build(:liability, commercial_entity: mock_entity)
+      entry.save!
+      saved_account = Account.find(entry.id)
+      expect(saved_account.commercial_entity).to eq(mock_entity)
+    end
+
   end
 end


### PR DESCRIPTION
This adds a polymorphic association named commercial_entity to accounts like the existing commercial_documents exists for entries. This allows the engine to be better separated from the other models in my projects. 

- updated initial migration
- run rails g plutus:add_commercial_entity_upgrade to upgrade
- added one trivial spec as required