### PR TITLE
BigDecimal compatibility for Ruby 2.7.1

### DIFF
--- a/app/models/plutus/account.rb
+++ b/app/models/plutus/account.rb
@@ -137,7 +137,7 @@ module Plutus
       if self.new.class == Plutus::Account
         raise(NoMethodError, "undefined method 'balance'")
       else
-        accounts_balance = BigDecimal.new('0')
+        accounts_balance = BigDecimal('0')
         accounts = self.all
         accounts.each do |account|
           if account.contra

--- a/app/models/plutus/amounts_extension.rb
+++ b/app/models/plutus/amounts_extension.rb
@@ -30,7 +30,7 @@ module Plutus
     #
     # Since this does not use the database for sumation, it may be used on non-persisted records.
     def balance_for_new_record
-      balance = BigDecimal.new('0')
+      balance = BigDecimal('0')
       each do |amount_record|
         if amount_record.amount && !amount_record.marked_for_destruction?
           balance += amount_record.amount # unless amount_record.marked_for_destruction?

--- a/spec/factories/amount_factory.rb
+++ b/spec/factories/amount_factory.rb
@@ -1,18 +1,18 @@
 FactoryGirl.define do
   factory :amount, :class => Plutus::Amount do |amount|
-    amount.amount BigDecimal.new('473')
+    amount.amount BigDecimal('473')
     amount.association :entry, :factory => :entry_with_credit_and_debit
     amount.association :account, :factory => :asset
   end
 
   factory :credit_amount, :class => Plutus::CreditAmount do |credit_amount|
-    credit_amount.amount BigDecimal.new('473')
+    credit_amount.amount BigDecimal('473')
     credit_amount.association :entry, :factory => :entry_with_credit_and_debit
     credit_amount.association :account, :factory => :revenue
   end
 
   factory :debit_amount, :class => Plutus::DebitAmount do |debit_amount|
-    debit_amount.amount BigDecimal.new('473')
+    debit_amount.amount BigDecimal('473')
     debit_amount.association :entry, :factory => :entry_with_credit_and_debit
     debit_amount.association :account, :factory => :asset
   end


### PR DESCRIPTION
https://stackoverflow.com/a/60491254

In BigDecimal version 2.0.0 you cannot use `BigDecimal.new` and do subclassing using Ruby > 2.4.