### PR TITLE
fixes rails 7.1 deprecation for ActiveRecord.default_timezone

### DIFF
--- a/app/models/plutus/entry.rb
+++ b/app/models/plutus/entry.rb
@@ -58,7 +58,13 @@ module Plutus
 
     private
       def default_date
-        todays_date = ActiveRecord::Base.default_timezone == :utc ? Time.now.utc : Time.now
+        default_timezone = if ActiveRecord.respond_to?(:default_timezone)
+          ActiveRecord.default_timezone
+        else
+          ActiveRecord::Base.default_timezone
+        end
+        todays_date = default_timezone == :utc ? Time.now.utc : Time.now
+        
         self.date ||= todays_date
       end
 


### PR DESCRIPTION
With Rails 7 we get deprecation warnings for creating new plutus entries:

```
DEPRECATION WARNING: ActiveRecord::Base.default_timezone is deprecated and will be removed in Rails 7.1.
Use `ActiveRecord.default_timezone` instead.
```

got this fix from activerecord-import
https://github.com/zdennis/activerecord-import/pull/752/files
